### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 moduleGenerator for shadps4 project
 
 When adding new libraries to shadPS4:
-- [ ] Add any new files to CMakeLists.txt
+- [ ] Add any new files to `CMakeLists.txt`
 - [ ] Add a call to RegisterlibSce... in `src/core/libraries/libs.cpp`
 - [ ] Add the generated library's logging class to `src/common/logging/filter.cpp` and `src/common/logging/types.h`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 moduleGenerator for shadps4 project
 
 When adding new libraries to shadPS4:
-- [ ] Add any new files to `CMakeLists.txt`
-- [ ] Add a call to RegisterlibSce... in `src/core/libraries/libs.cpp`
-- [ ] Add the generated library's logging class to `src/common/logging/filter.cpp` and `src/common/logging/types.h`
+- Add any new files to `CMakeLists.txt`
+- Add a call to RegisterlibSce... in `src/core/libraries/libs.cpp`
+- Add the generated library's logging class to `src/common/logging/filter.cpp` and `src/common/logging/types.h`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # moduleGenerator
 moduleGenerator for shadps4 project
+
+When adding new libraries to shadPS4:
+- [ ] Add any new files to CMakeLists.txt
+- [ ] Add a call to RegisterlibSce... in `src/core/libraries/libs.cpp`
+- [ ] Add the generated library's logging class to `src/common/logging/filter.cpp` and `src/common/logging/types.h`

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <filesystem>
@@ -21,7 +21,7 @@ struct NidFuncTable {
 };
 
 constexpr std::string_view SpdxHeader =
-    R"(// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+    R"(// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 )";
 


### PR DESCRIPTION
- Updates the generated copyright header to show 2025 instead of 2024
- Updates the copyright header in `main.cpp` with 2025 instead of 2024
- Adds notes in the README for how to merge generated libraries with shadPS4's main code.